### PR TITLE
Add missing spaces

### DIFF
--- a/lang/ko-kr/checklist.md
+++ b/lang/ko-kr/checklist.md
@@ -57,10 +57,10 @@ def my_task():
 
 ## Monitoring & Tests
 
-- [ ] 가능한한 더 많은 로그를 남기세요. 
-- [ ] 실패했을때 stack trace를 남기고 사람이 알 수 있도록 하세요. ([Sentry](https://sentry.io) 같은 서비스를 쓰는게 좋아요) 
+- [ ] 가능한 한 더 많은 로그를 남기세요. 
+- [ ] 실패했을 때 stack trace를 남기고 사람이 알 수 있도록 하세요. ([Sentry](https://sentry.io) 같은 서비스를 쓰는게 좋아요) 
 - [ ] [Flower: Real-time Celery web-monitor](http://docs.celeryproject.org/en/latest/userguide/monitoring.html#flower-real-time-celery-web-monitor)를 사용해서 샐러리 모니터링을 하세요. 
-- [ ] 태스크 호출을 테스트할때 `task_always_eager`를 사용하세요.
+- [ ] 태스크 호출을 테스트할 때 `task_always_eager`를 사용하세요.
 
 ## Resources
 


### PR DESCRIPTION
`~을 때` 의 경우에는 띄어쓰는 게 맞는 것 같습니다.
또한 `가능한한` 의 경우에도 `가능한` 과 `한` 사이에 띄어쓰기가 있어야 맞다고 생각되어서 수정했습니다.
수고 많으십니다. 감사합니다.